### PR TITLE
API reorganizations and extensions

### DIFF
--- a/3rdparty-prometheus4j/src/main/java/com/github/anhdat/models/VectorResponse.java
+++ b/3rdparty-prometheus4j/src/main/java/com/github/anhdat/models/VectorResponse.java
@@ -7,7 +7,7 @@ public class VectorResponse {
     String status;
     VectorData data;
 
-    static class VectorResult {
+    public static class VectorResult {
         Map<String, String> metric;
         List<Float> value;
 
@@ -29,7 +29,7 @@ public class VectorResponse {
         }
     }
 
-    static class VectorData {
+    public static class VectorData {
         String resultType;
         List<VectorResult> result;
         

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/ItemList.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/ItemList.java
@@ -1,0 +1,21 @@
+package eu.openaire.mas.delivery;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Object wrapper for a list, used so that at the HTTP API level
+ * all JSON responses are objects.
+ */
+public class ItemList<T> {
+    private final ArrayList<T> items;
+
+    public List<T> getItems() {
+	return items;
+    }
+
+    public ItemList(Collection<T> items) {
+	this.items = new ArrayList<>(items);
+    }
+}

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricEntry.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricEntry.java
@@ -7,25 +7,25 @@ package eu.openaire.mas.delivery;
  */
 public class MetricEntry {
 
-    private final String groupId;
+    private final String resourceId;
 
-    private final String metricId;
+    private final String kpiId;
     
     private final Object value;
     
-    public MetricEntry(String groupId, String metricId, Object value) {
+    public MetricEntry(String resourceId, String kpiId, Object value) {
         super();
-        this.groupId = groupId;
-        this.metricId = metricId;
+        this.resourceId = resourceId;
+        this.kpiId = kpiId;
         this.value = value;
     }    
     
-    public String getGroupId() {
-        return groupId;
+    public String getResourceId() {
+        return resourceId;
     }
 
-    public String getMetricId() {
-        return metricId;
+    public String getKpiId() {
+        return kpiId;
     }
 
     public Object getValue() {

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricEntry.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricEntry.java
@@ -11,9 +11,9 @@ public class MetricEntry {
 
     private final String kpiId;
     
-    private final Object value;
+    private final float value;
     
-    public MetricEntry(String resourceId, String kpiId, Object value) {
+    public MetricEntry(String resourceId, String kpiId, float value) {
         super();
         this.resourceId = resourceId;
         this.kpiId = kpiId;
@@ -28,7 +28,7 @@ public class MetricEntry {
         return kpiId;
     }
 
-    public Object getValue() {
+    public float getValue() {
         return value;
     }
     

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricMetadata.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricMetadata.java
@@ -1,0 +1,35 @@
+package eu.openaire.mas.delivery;
+
+public class MetricMetadata {
+
+    public enum MetricKind {
+	STATE, EVENT
+    }
+
+    private final String name;
+    private final String description;
+    private final String unit;
+    private final MetricKind type;
+
+    public MetricMetadata(String name, String description, String unit, MetricKind type) {
+	this.name = name;
+	this.description = description;
+	this.unit = unit;
+	this.type = type;
+    }
+
+    public String getName() {
+	return name;
+    }
+
+    public String getDescription() {
+	return description;
+    }
+
+    public String getUnit() {
+	return unit;
+    }
+    public MetricKind getType() {
+	return type;
+    }
+}

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
@@ -8,7 +8,7 @@ package eu.openaire.mas.delivery;
  */
 public interface MetricsDelivery {
 
-    MetricEntry deliver(String groupId, String metricId, String from, String to);
+    MetricEntry deliver(String groupId, String metricId);
 
     String[] list(String groupId);
     

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
@@ -1,5 +1,7 @@
 package eu.openaire.mas.delivery;
 
+import java.util.Map;
+
 /**
  * Metrics delivery API.
  * 
@@ -11,6 +13,10 @@ public interface MetricsDelivery {
     MetricEntry deliver(String groupId, String metricId);
 
     ItemList<String> list(String groupId);
+
+    MetricMetadata describe(String groupId, String metricId);
+
+    Map<String, MetricMetadata> describeResource(String groupId);
 
     ItemList<String> listResources();
 }

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
@@ -11,4 +11,6 @@ public interface MetricsDelivery {
     MetricEntry deliver(String groupId, String metricId);
 
     ItemList<String> list(String groupId);
+
+    ItemList<String> listResources();
 }

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
@@ -10,6 +10,5 @@ public interface MetricsDelivery {
 
     MetricEntry deliver(String groupId, String metricId);
 
-    String[] list(String groupId);
-    
+    ItemList<String> list(String groupId);
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import eu.openaire.mas.delivery.provider.MetricsProvider;
@@ -25,10 +24,8 @@ public class MetricsDeliveryController implements MetricsDelivery {
     @GetMapping("/metrics/{resourceId}/{kpiId}")
     public MetricEntry deliver(
             @PathVariable(value = "resourceId") String groupId,
-            @PathVariable(value = "kpiId") String metricId,
-            @RequestParam(value = "from", required = false) String from,
-            @RequestParam(value = "to", required = false) String to) {
-        return metricsProvider.deliver(groupId, metricId, from, to);
+            @PathVariable(value = "kpiId") String metricId) {
+        return metricsProvider.deliver(groupId, metricId, null, null);
     }
     
     @GetMapping("/metrics/{resourceId}")

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -29,16 +29,16 @@ public class MetricsDeliveryController implements MetricsDelivery {
     }
     
     @GetMapping("/metrics/{resourceId}")
-    public String[] list(
+    public ItemList<String> list(
             @PathVariable(value = "resourceId") String groupId) {
         Set<String> result = metricsProvider.list(groupId);
-        return result != null ? result.toArray(new String[result.size()]) : new String[0];
+	return new ItemList<>(result);
     }
 
     @GetMapping("/resources")
-    public String[] listResources() {
+    public ItemList<String> listResources() {
 	Set<String> resourceIds = metricsProvider.listResources();
-	return resourceIds.toArray(new String[resourceIds.size()]);
+	return new ItemList<>(resourceIds);
     }
 
     public void setMetricsProvider(MetricsProvider metricsProvider) {

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -1,5 +1,6 @@
 package eu.openaire.mas.delivery;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import eu.openaire.mas.delivery.provider.MetricsProvider;
+import eu.openaire.mas.delivery.provider.MetricsMetadataProvider;
 
 /**
  * RESTful metrics delivery controller.
@@ -21,14 +23,32 @@ public class MetricsDeliveryController implements MetricsDelivery {
     @Autowired
     private MetricsProvider metricsProvider;
 
-    @GetMapping("/metrics/{resourceId}/{kpiId}")
+    @Autowired
+    private MetricsMetadataProvider metricsMetadataProvider;
+
     @Override
+    @GetMapping("/metrics/{resourceId}/{kpiId}/value")
     public MetricEntry deliver(
             @PathVariable(value = "resourceId") String groupId,
             @PathVariable(value = "kpiId") String metricId) {
         return metricsProvider.deliver(groupId, metricId, null, null);
     }
-    
+
+    @Override
+    @GetMapping("/metrics/{resourceId}/{kpiId}")
+    public MetricMetadata describe(
+            @PathVariable(value = "resourceId") String resourceId,
+            @PathVariable(value = "kpiId") String kpiId) {
+        return metricsMetadataProvider.describe(resourceId, kpiId);
+    }
+
+    @Override
+    @GetMapping("/metrics/{resourceId}")
+    public Map<String, MetricMetadata> describeResource(
+	    @PathVariable(value = "resourceId") String resourceId) {
+        return metricsMetadataProvider.describeAll(resourceId);
+    }
+
     @Override
     @GetMapping("/ids/metrics/{resourceId}")
     public ItemList<String> list(

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -22,18 +22,18 @@ public class MetricsDeliveryController implements MetricsDelivery {
     @Autowired
     private MetricsProvider metricsProvider;
 
-    @GetMapping("/metrics/{groupId}/{metricId}")
+    @GetMapping("/metrics/{resourceId}/{kpiId}")
     public MetricEntry deliver(
-            @PathVariable(value = "groupId") String groupId,
-            @PathVariable(value = "metricId") String metricId,
+            @PathVariable(value = "resourceId") String groupId,
+            @PathVariable(value = "kpiId") String metricId,
             @RequestParam(value = "from", required = false) String from,
             @RequestParam(value = "to", required = false) String to) {
         return metricsProvider.deliver(groupId, metricId, from, to);
     }
     
-    @GetMapping("/metrics/{groupId}")
+    @GetMapping("/metrics/{resourceId}")
     public String[] list(
-            @PathVariable(value = "groupId") String groupId) {
+            @PathVariable(value = "resourceId") String groupId) {
         Set<String> result = metricsProvider.list(groupId);
         return result != null ? result.toArray(new String[result.size()]) : new String[0];
     }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -34,7 +34,13 @@ public class MetricsDeliveryController implements MetricsDelivery {
         Set<String> result = metricsProvider.list(groupId);
         return result != null ? result.toArray(new String[result.size()]) : new String[0];
     }
-    
+
+    @GetMapping("/resources")
+    public String[] listResources() {
+	Set<String> resourceIds = metricsProvider.listResources();
+	return resourceIds.toArray(new String[resourceIds.size()]);
+    }
+
     public void setMetricsProvider(MetricsProvider metricsProvider) {
         this.metricsProvider = metricsProvider;
     }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -22,6 +22,7 @@ public class MetricsDeliveryController implements MetricsDelivery {
     private MetricsProvider metricsProvider;
 
     @GetMapping("/metrics/{resourceId}/{kpiId}")
+    @Override
     public MetricEntry deliver(
             @PathVariable(value = "resourceId") String groupId,
             @PathVariable(value = "kpiId") String metricId) {
@@ -29,6 +30,7 @@ public class MetricsDeliveryController implements MetricsDelivery {
     }
     
     @GetMapping("/metrics/{resourceId}")
+    @Override
     public ItemList<String> list(
             @PathVariable(value = "resourceId") String groupId) {
         Set<String> result = metricsProvider.list(groupId);
@@ -36,6 +38,7 @@ public class MetricsDeliveryController implements MetricsDelivery {
     }
 
     @GetMapping("/resources")
+    @Override
     public ItemList<String> listResources() {
 	Set<String> resourceIds = metricsProvider.listResources();
 	return new ItemList<>(resourceIds);

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -29,16 +29,16 @@ public class MetricsDeliveryController implements MetricsDelivery {
         return metricsProvider.deliver(groupId, metricId, null, null);
     }
     
-    @GetMapping("/metrics/{resourceId}")
     @Override
+    @GetMapping("/ids/metrics/{resourceId}")
     public ItemList<String> list(
             @PathVariable(value = "resourceId") String groupId) {
         Set<String> result = metricsProvider.list(groupId);
 	return new ItemList<>(result);
     }
 
-    @GetMapping("/resources")
     @Override
+    @GetMapping("/ids/resources")
     public ItemList<String> listResources() {
 	Set<String> resourceIds = metricsProvider.listResources();
 	return new ItemList<>(resourceIds);

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/SwaggerConfig.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/SwaggerConfig.java
@@ -3,6 +3,7 @@ package eu.openaire.mas.delivery;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -12,6 +13,9 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class SwaggerConfig {
     @Bean
     public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2);
+        return new Docket(DocumentationType.SWAGGER_2)
+	    .select()
+	    .apis(RequestHandlerSelectors.basePackage("eu.openaire.mas"))
+	    .build();
     }
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMappingProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMappingProvider.java
@@ -10,6 +10,7 @@ import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -100,6 +101,11 @@ public class JsonFileBasedMappingProvider implements MappingProvider {
         } else {
             throw new MappingNotFoundException("unidentified group: " + groupId);    
         }
+    }
+
+    @Override
+    public Set<String> listGroups() {
+	return new HashSet<>(metricMappings.keySet());
     }
     
     /**

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMetadataMappingProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMetadataMappingProvider.java
@@ -1,0 +1,241 @@
+package eu.openaire.mas.delivery.mapping;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import eu.openaire.mas.delivery.MetricMetadata;
+import eu.openaire.mas.delivery.provider.MetricsMetadataProvider;
+
+/**
+ * Reads metadata mappings for KPIs from a JSON file.
+ */
+@Primary
+@Service
+public class JsonFileBasedMetadataMappingProvider implements MetricsMetadataProvider {
+
+    @Value("${metadata.mapping.location}")
+    private Resource fileLocation;
+
+    private static final Logger log = LoggerFactory.getLogger(JsonFileBasedMetadataMappingProvider.class);
+
+    /**
+     * Internal mapping identified by groupId and metricId on a 2nd map level.
+     */
+    private Map<String, Map<String,MetricMetadata>> metadataMappings = new ConcurrentHashMap<String, Map<String,MetricMetadata>>();
+
+    private ExecutorService fileWatcherExecutorService;
+
+    @PostConstruct
+    public void initialize() {
+        initializeMappings();
+        try {
+            WatchService watchService = FileSystems.getDefault().newWatchService();
+
+            Path path = fileLocation.getFile().getParentFile().toPath();
+
+            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE,
+                    StandardWatchEventKinds.ENTRY_MODIFY);
+
+            fileWatcherExecutorService = Executors.newSingleThreadExecutor();
+            fileWatcherExecutorService.execute(new MappingFileWatcher(watchService));
+        } catch (IOException e) {
+            throw new RuntimeException("unable to initialize mapping watcher service", e);
+        }
+
+    }
+
+    @PreDestroy
+    public void destroy() {
+        log.debug("shutting down mapping file watcher");
+        fileWatcherExecutorService.shutdownNow();
+    }
+
+    private MetricMetadata get(String groupId, String metricId) throws MappingNotFoundException {
+        Map<String, MetricMetadata> groupMap = metadataMappings.get(groupId);
+        if (groupMap != null) {
+            MetricMetadata result = groupMap.get(metricId);
+            if (result != null) {
+                return result;
+            } else {
+                throw new MappingNotFoundException(String.format("unidentified metric: '%s'" +
+                        " within the group: '%s'", metricId, groupId));
+            }
+        } else {
+            throw new MappingNotFoundException(String.format("unidentified group: '%s'", groupId));
+        }
+    }
+
+    private Set<String> listMetrics(String groupId) throws MappingNotFoundException {
+        Map<String, MetricMetadata> groupMap = metadataMappings.get(groupId);
+        if (groupMap != null) {
+            return groupMap.keySet();
+        } else {
+            throw new MappingNotFoundException("unidentified group: " + groupId);
+        }
+    }
+
+    @Override
+    public MetricMetadata describe(String groupId, String metricId) {
+	try {
+	    return get(groupId, metricId);
+	} catch (MappingNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    String.format("maping not found for groupId: '%s' and metricId: '%s'",
+                            groupId, metricId), e);
+        }
+    }
+
+    @Override
+    public Map<String, MetricMetadata> describeAll(String groupId) {
+	Map<String, MetricMetadata> result = new HashMap<>();
+
+	try {
+	    for (String metricId : listMetrics(groupId)) {
+		result.put(metricId, describe(groupId, metricId));
+	    }
+	} catch (MappingNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+		String.format("maping not found for groupId: '%s'", groupId), e);
+        }
+
+	return result;
+    }
+
+    /**
+     * Initializes in-memory mappings with the corresponding mapping file contents.
+     */
+    private void initializeMappings() {
+        try {
+            log.info("loading mappings from file: " + fileLocation.getURI().toString());
+            Map<String, Map<String, MetricMetadata>> readMap = getMap(getResourceFileAsString(fileLocation));
+            metadataMappings.clear();
+            for (Entry<String, Map<String, MetricMetadata>> entry : readMap.entrySet()) {
+                metadataMappings.put(entry.getKey(), new ConcurrentHashMap<String, MetricMetadata>(entry.getValue()));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Checks whether notification is related to a mapping file.
+     */
+    private boolean isMappingFile(Path mappingFile) {
+        return fileLocation.getFilename().contentEquals(mappingFile.toString());
+    }
+
+    /**
+     * Converts mappings defined as JSON into the object representation.
+     */
+    static Map<String, Map<String, MetricMetadata>> getMap(String jsonContent) {
+        Gson gson = new Gson();
+        java.lang.reflect.Type empMapType = new TypeToken<Map<String, Map<String, MetricMetadata>>>() {}.getType();
+        return gson.fromJson(jsonContent, empMapType);
+    }
+
+    /**
+     * Loads contents of a given resource into String.
+     */
+    static String getResourceFileAsString(Resource resource) throws IOException {
+        try (InputStream is = resource.getInputStream()) {
+            if (is == null) {
+                throw new IOException("unable to get stream for a resource: " + resource.getURI());
+            }
+            return getInputStreamContents(is);
+        }
+    }
+
+    static String getResourceFileAsString(String fileName) throws IOException {
+        try (InputStream is = ClassLoader.getSystemClassLoader().getResourceAsStream(fileName)) {
+            if (is == null) {
+                throw new IOException("unable to get stream for a file: " + fileName);
+            }
+            return getInputStreamContents(is);
+        }
+    }
+
+    private static String getInputStreamContents(InputStream is) throws IOException {
+        try (InputStreamReader isr = new InputStreamReader(is, "utf8"); BufferedReader reader = new BufferedReader(isr)) {
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        }
+    }
+
+    /**
+     * Watcher class responsible for handling mapping file modifications by syncing
+     * in memory mapping state with the file contents.
+     *
+     */
+    class MappingFileWatcher implements Runnable {
+
+        private WatchService watchService;
+
+        public MappingFileWatcher(WatchService watchService) {
+            this.watchService = watchService;
+        }
+
+        @Override
+        public void run() {
+            try {
+                WatchKey key;
+                while ((key = watchService.take()) != null) {
+                    for (WatchEvent<?> event : key.pollEvents()) {
+
+                        if (isMappingFile((Path) event.context())) {
+                            if (event.kind().equals(StandardWatchEventKinds.ENTRY_DELETE)) {
+                                log.info("handling file related event by removing all the mappings");
+                                metadataMappings.clear();
+                            } else if (event.kind().equals(StandardWatchEventKinds.ENTRY_CREATE)
+                                    || event.kind().equals(StandardWatchEventKinds.ENTRY_MODIFY)) {
+                                log.info("handling file related event by reinitializing the mappings");
+                                initializeMappings();
+                            } else {
+                                log.warn("unsupported event kind: " + event.kind());
+                            }
+                            log.info("hanlding operation: " + event.kind() + " on file: " + event.context() + " is done");
+                        } else {
+                            log.debug("got notification unrelated to the mapping file: " + event.context());
+                        }
+
+                    }
+                    key.reset();
+                }
+            } catch (InterruptedException e) {
+                log.info("got interrupted, finishing mapping file watcher job");
+            }
+
+            log.debug("mapping file watcher job is done");
+        }
+
+    }
+}

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/MappingProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/MappingProvider.java
@@ -7,4 +7,6 @@ public interface MappingProvider {
     PrometheusMetricMeta get(String groupId, String metricId) throws MappingNotFoundException;
     
     Set<String> listMetrics(String groupId) throws MappingNotFoundException;
+
+    Set<String> listGroups();
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsMetadataProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsMetadataProvider.java
@@ -1,0 +1,33 @@
+package eu.openaire.mas.delivery.provider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import eu.openaire.mas.delivery.MetricMetadata;
+import eu.openaire.mas.delivery.MetricMetadata.MetricKind;
+
+@Service
+public class DummyMetricsMetadataProvider implements MetricsMetadataProvider {
+
+    @Autowired
+    private MetricsProvider metricsProvider;
+
+    @Override
+    public MetricMetadata describe(String groupId, String metricId) {
+	return new MetricMetadata(groupId+" "+metricId, "Lorem ipsum...", "attoparsec", MetricKind.STATE);
+    }
+
+    @Override
+    public Map<String, MetricMetadata> describeAll(String groupId) {
+	Map<String, MetricMetadata> result = new HashMap<>();
+
+	for (String metricId : metricsProvider.list(groupId)) {
+	    result.put(metricId, describe(groupId, metricId));
+	}
+
+	return result;
+    }
+}

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
@@ -30,4 +30,8 @@ public class DummyMetricsProvider implements MetricsProvider {
         return new HashSet<String>(Arrays.asList(new String[] {"dummy"}));
     }
 
+    @Override
+    public Set<String> listResources() {
+	return new HashSet<String>(Arrays.asList(new String[] {"dummy"}));
+    }
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
@@ -18,12 +18,11 @@ import eu.openaire.mas.delivery.MetricEntry;
 @Service
 public class DummyMetricsProvider implements MetricsProvider {
 
-    private static final String template = "measurements count: %s";
     private final AtomicLong counter = new AtomicLong();
 
     @Override
     public MetricEntry deliver(String groupId, String metricId, String from, String to) {
-        return new MetricEntry(groupId, metricId, String.format(template, counter.incrementAndGet()));
+        return new MetricEntry(groupId, metricId, counter.incrementAndGet());
     }
 
     @Override

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsMetadataProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsMetadataProvider.java
@@ -1,0 +1,18 @@
+package eu.openaire.mas.delivery.provider;
+
+import java.util.Map;
+
+import eu.openaire.mas.delivery.MetricMetadata;
+
+public interface MetricsMetadataProvider {
+
+    /**
+     * Returns metric metadata
+     */
+    MetricMetadata describe(String groupId, String metricId);
+
+    /**
+     * Returns metric metadata for all metrics in a group
+     */
+    Map<String, MetricMetadata> describeAll(String groupId);
+}

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsProvider.java
@@ -21,4 +21,9 @@ public interface MetricsProvider {
      * Lists metric identifiers for a given group.
      */
     Set<String> list(String groupId);
+
+    /**
+     * List all known resource identifiers
+     */
+    Set<String> listResources();
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
@@ -53,7 +53,8 @@ public class PrometheusMetricsProvider implements MetricsProvider {
                     // FIXME it is just a sample, include "from" and "to" params in querying
                     VectorResponse resp = prometheusClient.query(meta.getQuery());
                     if (STATUS_SUCCESS.equals(resp.getStatus())) {
-                        return new MetricEntry(groupId, metricId, resp.getData());    
+			float value = resp.getData().getResult().get(0).getValue().get(1);
+                        return new MetricEntry(groupId, metricId, value);
                     } else {
                         throw new RuntimeException(String.format("invalid status: %, full response: %s",
                                 resp.getStatus(), resp));

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
@@ -85,5 +85,9 @@ public class PrometheusMetricsProvider implements MetricsProvider {
                     "maping not found for groupId: " + groupId, e);
         }
     }
-    
+
+    @Override
+    public Set<String> listResources() {
+	return mappingProvider.listGroups();
+    }
 }

--- a/metrics-delivery-endpoint-impl/src/main/resources/application.properties
+++ b/metrics-delivery-endpoint-impl/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 #metrics.mapping.location=classpath:eu/openaire/mas/delivery/mapping/metrics_mappings.json
-metrics.mapping.location=file:${user.home}/mas/metrics_mappings.json
+config.directory=${user.home}/mas
+metrics.mapping.location=file:${config.directory}/metrics_mappings.json
+metadata.mapping.location=file:${config.directory}/metadata_mappings.json
 prometheus.server.location=http://localhost:9090/

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -60,9 +59,9 @@ public class MetricsDeliveryControllerTest {
 	Set<String> resourceSet = singleton(resId);
 	when(metricsProvider.listResources()).thenReturn(resourceSet);
 
-	String[] result = metricsDeliveryController.listResources();
+	ItemList<String> result = metricsDeliveryController.listResources();
 
-	HashSet<String> resultSet = new HashSet<String>(Arrays.asList(result));
+	HashSet<String> resultSet = new HashSet<>(result.getItems());
 	assertEquals(resourceSet, resultSet);
     }
 }

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -39,7 +39,7 @@ public class MetricsDeliveryControllerTest {
         Mockito.when(metricsProvider.deliver(familyId, name, null, null)).thenReturn(kpiEntry);
         
         // execute
-        MetricEntry result = metricsDeliveryController.deliver(familyId, name, null, null);
+        MetricEntry result = metricsDeliveryController.deliver(familyId, name);
         
         // assert
         assertNotNull(result);

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -1,7 +1,13 @@
 package eu.openaire.mas.delivery;
 
+import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,5 +52,17 @@ public class MetricsDeliveryControllerTest {
         assertEquals(familyId, result.getResourceId());
         assertEquals(name, result.getKpiId());
         assertEquals(value, result.getValue());
+    }
+
+    @Test
+    public void listResourcesPassesIdReturnedByProvider() {
+	String resId = "resource";
+	Set<String> resourceSet = singleton(resId);
+	when(metricsProvider.listResources()).thenReturn(resourceSet);
+
+	String[] result = metricsDeliveryController.listResources();
+
+	HashSet<String> resultSet = new HashSet<String>(Arrays.asList(result));
+	assertEquals(resourceSet, resultSet);
     }
 }

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -43,8 +43,8 @@ public class MetricsDeliveryControllerTest {
         
         // assert
         assertNotNull(result);
-        assertEquals(familyId, result.getGroupId());
-        assertEquals(name, result.getMetricId());
+        assertEquals(familyId, result.getResourceId());
+        assertEquals(name, result.getKpiId());
         assertEquals(value, result.getValue());
     }
 }

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -34,7 +34,7 @@ public class MetricsDeliveryControllerTest {
         // given
         String familyId = "someFamId";
         String name = "someName";
-        String value = "1";
+        float value = 1;
         MetricEntry kpiEntry = new MetricEntry(familyId, name, value);        
         Mockito.when(metricsProvider.deliver(familyId, name, null, null)).thenReturn(kpiEntry);
         


### PR DESCRIPTION
This could be clearer as 3 separate pull requests but the changes are on one hand not that big
and on the other harder to separate than I expected.

1. a small cleanup
- Include only our own API in Swagger docs
2. API reorganizations
- rename API parameters and response fields to use less generic names
- return only KPI value instead of raw Prometheus response
- always use JSON objects as responses
- remove from and to parameters from the API
- move HTTP paths returning identifier lists under `/ids`
3. API extensions
- Add a method to list known resource identifiers
- Implement returning KPI metadata - closes #17