### PR TITLE
Consistently use resource/metric terminology

### DIFF
--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricEntry.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricEntry.java
@@ -1,7 +1,7 @@
 package eu.openaire.mas.delivery;
 
 /**
- * Represents KPI record.
+ * Represents a metric record.
  * @author mhorst
  *
  */
@@ -9,14 +9,14 @@ public class MetricEntry {
 
     private final String resourceId;
 
-    private final String kpiId;
+    private final String metricId;
     
     private final float value;
     
-    public MetricEntry(String resourceId, String kpiId, float value) {
+    public MetricEntry(String resourceId, String metricId, float value) {
         super();
         this.resourceId = resourceId;
-        this.kpiId = kpiId;
+        this.metricId = metricId;
         this.value = value;
     }    
     
@@ -24,8 +24,8 @@ public class MetricEntry {
         return resourceId;
     }
 
-    public String getKpiId() {
-        return kpiId;
+    public String getMetricId() {
+        return metricId;
     }
 
     public float getValue() {

--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
@@ -10,13 +10,13 @@ import java.util.Map;
  */
 public interface MetricsDelivery {
 
-    MetricEntry deliver(String groupId, String metricId);
+    MetricEntry deliver(String resourceId, String metricId);
 
-    ItemList<String> list(String groupId);
+    ItemList<String> list(String resourceId);
 
-    MetricMetadata describe(String groupId, String metricId);
+    MetricMetadata describe(String resourceId, String metricId);
 
-    Map<String, MetricMetadata> describeResource(String groupId);
+    Map<String, MetricMetadata> describeResource(String resourceId);
 
     ItemList<String> listResources();
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -27,19 +27,19 @@ public class MetricsDeliveryController implements MetricsDelivery {
     private MetricsMetadataProvider metricsMetadataProvider;
 
     @Override
-    @GetMapping("/metrics/{resourceId}/{kpiId}/value")
+    @GetMapping("/metrics/{resourceId}/{metricId}/value")
     public MetricEntry deliver(
-            @PathVariable(value = "resourceId") String groupId,
-            @PathVariable(value = "kpiId") String metricId) {
-        return metricsProvider.deliver(groupId, metricId, null, null);
+            @PathVariable(value = "resourceId") String resourceId,
+            @PathVariable(value = "metricId") String metricId) {
+        return metricsProvider.deliver(resourceId, metricId, null, null);
     }
 
     @Override
-    @GetMapping("/metrics/{resourceId}/{kpiId}")
+    @GetMapping("/metrics/{resourceId}/{metricId}")
     public MetricMetadata describe(
             @PathVariable(value = "resourceId") String resourceId,
-            @PathVariable(value = "kpiId") String kpiId) {
-        return metricsMetadataProvider.describe(resourceId, kpiId);
+            @PathVariable(value = "metricId") String metricId) {
+        return metricsMetadataProvider.describe(resourceId, metricId);
     }
 
     @Override
@@ -52,8 +52,8 @@ public class MetricsDeliveryController implements MetricsDelivery {
     @Override
     @GetMapping("/ids/metrics/{resourceId}")
     public ItemList<String> list(
-            @PathVariable(value = "resourceId") String groupId) {
-        Set<String> result = metricsProvider.list(groupId);
+            @PathVariable(value = "resourceId") String resourceId) {
+        Set<String> result = metricsProvider.list(resourceId);
 	return new ItemList<>(result);
     }
 

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMappingProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMappingProvider.java
@@ -33,7 +33,7 @@ import com.google.gson.reflect.TypeToken;
 
 /**
  * Reads mappings from a set of files stored in a given directory.
- * Each filename identifies single group and encapsulates multiple metrics mappings.s
+ * Each filename identifies single resource and encapsulates multiple metrics mappings.s
  * @author mhorst
  *
  */
@@ -46,7 +46,7 @@ public class JsonFileBasedMappingProvider implements MappingProvider {
     private static final Logger log = LoggerFactory.getLogger(JsonFileBasedMappingProvider.class);
     
     /**
-     * Internal mapping identified by groupId and metricId on a 2nd map level.
+     * Internal mapping identified by resourceId and metricId on a 2nd map level.
      */
     private Map<String, Map<String,PrometheusMetricMeta>> metricMappings = new ConcurrentHashMap<String, Map<String,PrometheusMetricMeta>>();
     
@@ -78,33 +78,33 @@ public class JsonFileBasedMappingProvider implements MappingProvider {
     }
     
     @Override
-    public PrometheusMetricMeta get(String groupId, String metricId) throws MappingNotFoundException {
-        Map<String, PrometheusMetricMeta> groupMap = metricMappings.get(groupId);
-        if (groupMap != null) {
-            PrometheusMetricMeta result = groupMap.get(metricId);
+    public PrometheusMetricMeta get(String resourceId, String metricId) throws MappingNotFoundException {
+        Map<String, PrometheusMetricMeta> resourceMap = metricMappings.get(resourceId);
+        if (resourceMap != null) {
+            PrometheusMetricMeta result = resourceMap.get(metricId);
             if (result != null) {
                 return result;
             } else {
                 throw new MappingNotFoundException(String.format("unidentified metric: '%s'" + 
-                        " within the group: '%s'", metricId, groupId));
+                        " for the resource: '%s'", metricId, resourceId));
             }
         } else {
-            throw new MappingNotFoundException(String.format("unidentified group: '%s'", groupId));    
+            throw new MappingNotFoundException(String.format("unidentified resource: '%s'", resourceId));
         }
     }
     
     @Override
-    public Set<String> listMetrics(String groupId) throws MappingNotFoundException {
-        Map<String, PrometheusMetricMeta> groupMap = metricMappings.get(groupId);
-        if (groupMap != null) {
-            return groupMap.keySet();
+    public Set<String> listMetrics(String resourceId) throws MappingNotFoundException {
+        Map<String, PrometheusMetricMeta> resourceMap = metricMappings.get(resourceId);
+        if (resourceMap != null) {
+            return resourceMap.keySet();
         } else {
-            throw new MappingNotFoundException("unidentified group: " + groupId);    
+            throw new MappingNotFoundException("unidentified resource: " + resourceId);
         }
     }
 
     @Override
-    public Set<String> listGroups() {
+    public Set<String> listResources() {
 	return new HashSet<>(metricMappings.keySet());
     }
     

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMetadataMappingProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/JsonFileBasedMetadataMappingProvider.java
@@ -38,7 +38,7 @@ import eu.openaire.mas.delivery.MetricMetadata;
 import eu.openaire.mas.delivery.provider.MetricsMetadataProvider;
 
 /**
- * Reads metadata mappings for KPIs from a JSON file.
+ * Reads metadata mappings for metrics from a JSON file.
  */
 @Primary
 @Service
@@ -50,7 +50,7 @@ public class JsonFileBasedMetadataMappingProvider implements MetricsMetadataProv
     private static final Logger log = LoggerFactory.getLogger(JsonFileBasedMetadataMappingProvider.class);
 
     /**
-     * Internal mapping identified by groupId and metricId on a 2nd map level.
+     * Internal mapping identified by resourceId and metricId on a 2nd map level.
      */
     private Map<String, Map<String,MetricMetadata>> metadataMappings = new ConcurrentHashMap<String, Map<String,MetricMetadata>>();
 
@@ -81,52 +81,52 @@ public class JsonFileBasedMetadataMappingProvider implements MetricsMetadataProv
         fileWatcherExecutorService.shutdownNow();
     }
 
-    private MetricMetadata get(String groupId, String metricId) throws MappingNotFoundException {
-        Map<String, MetricMetadata> groupMap = metadataMappings.get(groupId);
-        if (groupMap != null) {
-            MetricMetadata result = groupMap.get(metricId);
+    private MetricMetadata get(String resourceId, String metricId) throws MappingNotFoundException {
+        Map<String, MetricMetadata> resourceMap = metadataMappings.get(resourceId);
+        if (resourceMap != null) {
+            MetricMetadata result = resourceMap.get(metricId);
             if (result != null) {
                 return result;
             } else {
                 throw new MappingNotFoundException(String.format("unidentified metric: '%s'" +
-                        " within the group: '%s'", metricId, groupId));
+                        " for the resource: '%s'", metricId, resourceId));
             }
         } else {
-            throw new MappingNotFoundException(String.format("unidentified group: '%s'", groupId));
+            throw new MappingNotFoundException(String.format("unidentified resource: '%s'", resourceId));
         }
     }
 
-    private Set<String> listMetrics(String groupId) throws MappingNotFoundException {
-        Map<String, MetricMetadata> groupMap = metadataMappings.get(groupId);
-        if (groupMap != null) {
-            return groupMap.keySet();
+    private Set<String> listMetrics(String resourceId) throws MappingNotFoundException {
+        Map<String, MetricMetadata> resourceMap = metadataMappings.get(resourceId);
+        if (resourceMap != null) {
+            return resourceMap.keySet();
         } else {
-            throw new MappingNotFoundException("unidentified group: " + groupId);
+            throw new MappingNotFoundException("unidentified resource: " + resourceId);
         }
     }
 
     @Override
-    public MetricMetadata describe(String groupId, String metricId) {
+    public MetricMetadata describe(String resourceId, String metricId) {
 	try {
-	    return get(groupId, metricId);
+	    return get(resourceId, metricId);
 	} catch (MappingNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    String.format("maping not found for groupId: '%s' and metricId: '%s'",
-                            groupId, metricId), e);
+                    String.format("maping not found for resourceId: '%s' and metricId: '%s'",
+                            resourceId, metricId), e);
         }
     }
 
     @Override
-    public Map<String, MetricMetadata> describeAll(String groupId) {
+    public Map<String, MetricMetadata> describeAll(String resourceId) {
 	Map<String, MetricMetadata> result = new HashMap<>();
 
 	try {
-	    for (String metricId : listMetrics(groupId)) {
-		result.put(metricId, describe(groupId, metricId));
+	    for (String metricId : listMetrics(resourceId)) {
+		result.put(metricId, describe(resourceId, metricId));
 	    }
 	} catch (MappingNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-		String.format("maping not found for groupId: '%s'", groupId), e);
+		String.format("maping not found for resourceId: '%s'", resourceId), e);
         }
 
 	return result;

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/MappingProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/mapping/MappingProvider.java
@@ -4,9 +4,9 @@ import java.util.Set;
 
 public interface MappingProvider {
 
-    PrometheusMetricMeta get(String groupId, String metricId) throws MappingNotFoundException;
+    PrometheusMetricMeta get(String resourceId, String metricId) throws MappingNotFoundException;
     
-    Set<String> listMetrics(String groupId) throws MappingNotFoundException;
+    Set<String> listMetrics(String resourceId) throws MappingNotFoundException;
 
-    Set<String> listGroups();
+    Set<String> listResources();
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsMetadataProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsMetadataProvider.java
@@ -16,16 +16,16 @@ public class DummyMetricsMetadataProvider implements MetricsMetadataProvider {
     private MetricsProvider metricsProvider;
 
     @Override
-    public MetricMetadata describe(String groupId, String metricId) {
-	return new MetricMetadata(groupId+" "+metricId, "Lorem ipsum...", "attoparsec", MetricKind.STATE);
+    public MetricMetadata describe(String resourceId, String metricId) {
+	return new MetricMetadata(resourceId+" "+metricId, "Lorem ipsum...", "attoparsec", MetricKind.STATE);
     }
 
     @Override
-    public Map<String, MetricMetadata> describeAll(String groupId) {
+    public Map<String, MetricMetadata> describeAll(String resourceId) {
 	Map<String, MetricMetadata> result = new HashMap<>();
 
-	for (String metricId : metricsProvider.list(groupId)) {
-	    result.put(metricId, describe(groupId, metricId));
+	for (String metricId : metricsProvider.list(resourceId)) {
+	    result.put(metricId, describe(resourceId, metricId));
 	}
 
 	return result;

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
@@ -21,12 +21,12 @@ public class DummyMetricsProvider implements MetricsProvider {
     private final AtomicLong counter = new AtomicLong();
 
     @Override
-    public MetricEntry deliver(String groupId, String metricId, String from, String to) {
-        return new MetricEntry(groupId, metricId, counter.incrementAndGet());
+    public MetricEntry deliver(String resourceId, String metricId, String from, String to) {
+        return new MetricEntry(resourceId, metricId, counter.incrementAndGet());
     }
 
     @Override
-    public Set<String> list(String groupId) {
+    public Set<String> list(String resourceId) {
         return new HashSet<String>(Arrays.asList(new String[] {"dummy"}));
     }
 

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsMetadataProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsMetadataProvider.java
@@ -9,10 +9,10 @@ public interface MetricsMetadataProvider {
     /**
      * Returns metric metadata
      */
-    MetricMetadata describe(String groupId, String metricId);
+    MetricMetadata describe(String resourceId, String metricId);
 
     /**
-     * Returns metric metadata for all metrics in a group
+     * Returns metric metadata for all metrics of a resource
      */
-    Map<String, MetricMetadata> describeAll(String groupId);
+    Map<String, MetricMetadata> describeAll(String resourceId);
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsProvider.java
@@ -15,12 +15,12 @@ public interface MetricsProvider {
     /**
      * Delivers metric details.
      */
-    MetricEntry deliver(String groupId, String metricId, String from, String to);
+    MetricEntry deliver(String resourceId, String metricId, String from, String to);
     
     /**
-     * Lists metric identifiers for a given group.
+     * Lists metric identifiers for a given resource.
      */
-    Set<String> list(String groupId);
+    Set<String> list(String resourceId);
 
     /**
      * List all known resource identifiers

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
@@ -45,16 +45,16 @@ public class PrometheusMetricsProvider implements MetricsProvider {
     }
     
     @Override
-    public MetricEntry deliver(String groupId, String metricId, String from, String to) {
+    public MetricEntry deliver(String resourceId, String metricId, String from, String to) {
         try {
-            PrometheusMetricMeta meta = mappingProvider.get(groupId, metricId);
+            PrometheusMetricMeta meta = mappingProvider.get(resourceId, metricId);
             if (meta!=null) {
                 try {
                     // FIXME it is just a sample, include "from" and "to" params in querying
                     VectorResponse resp = prometheusClient.query(meta.getQuery());
                     if (STATUS_SUCCESS.equals(resp.getStatus())) {
 			float value = resp.getData().getResult().get(0).getValue().get(1);
-                        return new MetricEntry(groupId, metricId, value);
+                        return new MetricEntry(resourceId, metricId, value);
                     } else {
                         throw new RuntimeException(String.format("invalid status: %, full response: %s",
                                 resp.getStatus(), resp));
@@ -66,28 +66,28 @@ public class PrometheusMetricsProvider implements MetricsProvider {
             } else {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, 
                         String.format("unable to find query mappings for "
-                                + "group: %s and metric: %s", groupId, metricId));
+                                + "resource: %s and metric: %s", resourceId, metricId));
             }    
         } catch (MappingNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    String.format("maping not found for groupId: '%s' and metricId: '%s'", 
-                            groupId, metricId), e);
+                    String.format("maping not found for resourceId: '%s' and metricId: '%s'",
+                            resourceId, metricId), e);
         }
         
     }
 
     @Override
-    public Set<String> list(String groupId) {
+    public Set<String> list(String resourceId) {
         try {
-            return mappingProvider.listMetrics(groupId);
+            return mappingProvider.listMetrics(resourceId);
         } catch (MappingNotFoundException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, 
-                    "maping not found for groupId: " + groupId, e);
+                    "maping not found for resourceId: " + resourceId, e);
         }
     }
 
     @Override
     public Set<String> listResources() {
-	return mappingProvider.listGroups();
+	return mappingProvider.listResources();
     }
 }

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -40,8 +40,8 @@ public class MetricsDeliveryControllerTest {
         String familyId = "someFamId";
         String name = "someName";
         float value = 1;
-        MetricEntry kpiEntry = new MetricEntry(familyId, name, value);        
-        Mockito.when(metricsProvider.deliver(familyId, name, null, null)).thenReturn(kpiEntry);
+        MetricEntry metricEntry = new MetricEntry(familyId, name, value);
+        Mockito.when(metricsProvider.deliver(familyId, name, null, null)).thenReturn(metricEntry);
         
         // execute
         MetricEntry result = metricsDeliveryController.deliver(familyId, name);
@@ -49,7 +49,7 @@ public class MetricsDeliveryControllerTest {
         // assert
         assertNotNull(result);
         assertEquals(familyId, result.getResourceId());
-        assertEquals(name, result.getKpiId());
+        assertEquals(name, result.getMetricId());
         assertEquals(value, result.getValue());
     }
 


### PR DESCRIPTION
Closes #20.
Following the HTTP API changes started in 73aa267 replace internal
uses of 'group' with 'resource' as well.
At the same time back off from the 'metric' -> 'kpi' change started in
that commit and use 'metric' everywhere. To be fully consistent
otherwise would require changes to many class names and to some HTTP
API paths and not every value reported by the service is going to be
'key' anyway.