### PR TITLE
Approach to handling of special-case metrics not compatible with PromQL

### DIFF
--- a/3rdparty-prometheus4j/src/main/java/com/github/anhdat/PrometheusApiClient.java
+++ b/3rdparty-prometheus4j/src/main/java/com/github/anhdat/PrometheusApiClient.java
@@ -29,6 +29,10 @@ public class PrometheusApiClient {
         return service.query(query, time, null).execute().body();
     }
 
+    public MatrixResponse queryMatrix(String query, String time) throws IOException {
+        return service.queryMatrix(query, time, null).execute().body();
+    }
+
     public VectorResponse query(String query, String time, String timeout) throws IOException {
         return service.query(query, time, timeout).execute().body();
     }

--- a/3rdparty-prometheus4j/src/main/java/com/github/anhdat/PrometheusRest.java
+++ b/3rdparty-prometheus4j/src/main/java/com/github/anhdat/PrometheusRest.java
@@ -16,6 +16,13 @@ public interface PrometheusRest {
         @Query("timeout") String timeout
     );
 
+    @GET("api/v1/query")
+    Call<MatrixResponse> queryMatrix(
+        @Query("query") String query,
+        @Query("time") String time,
+        @Query("timeout") String timeout
+    );
+
     @GET("api/v1/query_range")
     Call<MatrixResponse> queryRange(
         @Query("query") String query,

--- a/3rdparty-prometheus4j/src/main/java/com/github/anhdat/models/MatrixResponse.java
+++ b/3rdparty-prometheus4j/src/main/java/com/github/anhdat/models/MatrixResponse.java
@@ -7,7 +7,7 @@ public class MatrixResponse {
     String status;
     MatrixData data;
 
-    static class MatrixData {
+    public static class MatrixData {
         String resultType;
         List<MatrixResult> result;
         
@@ -19,7 +19,7 @@ public class MatrixResponse {
         }
     }
 
-    static class MatrixResult {
+    public static class MatrixResult {
         Map<String, String> metric;
         List<List<Float>> values;
 

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/ExpressionContext.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/ExpressionContext.java
@@ -1,6 +1,11 @@
 package eu.openaire.mas.delivery.provider;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+
 import com.github.anhdat.PrometheusApiClient;
+import com.github.anhdat.models.MatrixResponse;
 
 /**
  * Context for SpEL expressions executed by PrometheusMetricsProvider.
@@ -10,5 +15,38 @@ class ExpressionContext {
 
     ExpressionContext(PrometheusApiClient prometheusClient) {
 	this.prometheusClient = prometheusClient;
+    }
+
+    /**
+     * Sums values of a series provided periodically for which there is another series provided
+     * in the same exposition which is different (usually because it represents a timestamp) for each
+     * new value of the series to sum.
+     *
+     * @param countsSeries the series to sum
+     * @param stampsSeries the series of timestamps
+     * @param from initial timestamp to go back to
+     * @return sum of values from the countsSeries matching each distinct value of the stampsSeries
+     */
+    public float sumPeriods(String countsSeries, String stampsSeries, long from) throws IOException {
+	long now = System.currentTimeMillis() / 1000;
+	String range = "[" + (now - from) +"s]";
+	MatrixResponse rc = prometheusClient.queryMatrix(countsSeries+range, ""+now);
+	MatrixResponse rs = prometheusClient.queryMatrix(stampsSeries+range, ""+now);
+	List<List<Float>> stamps = rs.getData().getResult().get(0).getValues();
+	HashSet<Float> uniqueStamps = new HashSet<>();
+	HashSet<Float> uniqueStampsStamps = new HashSet<>();
+	for (List<Float> pair : stamps) {
+	    if (uniqueStamps.add(pair.get(1))) {
+		uniqueStampsStamps.add(pair.get(0));
+	    }
+	}
+	float sum = 0;
+	List<List<Float>> counts = rc.getData().getResult().get(0).getValues();
+	for (List<Float> pair : counts) {
+	    if (uniqueStampsStamps.contains(pair.get(0))) {
+		sum += pair.get(1);
+	    }
+	}
+	return sum;
     }
 }

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/ExpressionContext.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/ExpressionContext.java
@@ -1,0 +1,14 @@
+package eu.openaire.mas.delivery.provider;
+
+import com.github.anhdat.PrometheusApiClient;
+
+/**
+ * Context for SpEL expressions executed by PrometheusMetricsProvider.
+ */
+class ExpressionContext {
+    private PrometheusApiClient prometheusClient;
+
+    ExpressionContext(PrometheusApiClient prometheusClient) {
+	this.prometheusClient = prometheusClient;
+    }
+}


### PR DESCRIPTION
Based on the case of OAPC API requests - a metric that is provided periodically with a value for the prevoius month - so not a proper counter, but should be presented accumulated over a period.
For some flexibility and to avoid hardcoding of series/metrics names in the Java code, use SpEL expressions in the mapping file,
calling to the special-case (but maybe reusable) Java code.
