### PR TITLE
Get a metric value for a specified moment in time

### DIFF
--- a/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
+++ b/metrics-delivery-endpoint-api/src/main/java/eu/openaire/mas/delivery/MetricsDelivery.java
@@ -10,7 +10,7 @@ import java.util.Map;
  */
 public interface MetricsDelivery {
 
-    MetricEntry deliver(String resourceId, String metricId);
+    MetricEntry deliver(String resourceId, String metricId, Long timestamp);
 
     ItemList<String> list(String resourceId);
 

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -33,7 +33,10 @@ public class MetricsDeliveryController implements MetricsDelivery {
             @PathVariable(value = "resourceId") String resourceId,
             @PathVariable(value = "metricId") String metricId,
 	    @RequestParam(value = "time", required = false) Long time) {
-        return metricsProvider.deliver(resourceId, metricId, null, null);
+	if (time == null) {
+	    time = System.currentTimeMillis() / 1000;
+	}
+        return metricsProvider.deliver(resourceId, metricId, time);
     }
 
     @Override

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/MetricsDeliveryController.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import eu.openaire.mas.delivery.provider.MetricsProvider;
@@ -30,7 +31,8 @@ public class MetricsDeliveryController implements MetricsDelivery {
     @GetMapping("/metrics/{resourceId}/{metricId}/value")
     public MetricEntry deliver(
             @PathVariable(value = "resourceId") String resourceId,
-            @PathVariable(value = "metricId") String metricId) {
+            @PathVariable(value = "metricId") String metricId,
+	    @RequestParam(value = "time", required = false) Long time) {
         return metricsProvider.deliver(resourceId, metricId, null, null);
     }
 

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/DummyMetricsProvider.java
@@ -21,7 +21,7 @@ public class DummyMetricsProvider implements MetricsProvider {
     private final AtomicLong counter = new AtomicLong();
 
     @Override
-    public MetricEntry deliver(String resourceId, String metricId, String from, String to) {
+    public MetricEntry deliver(String resourceId, String metricId, long timestamp) {
         return new MetricEntry(resourceId, metricId, counter.incrementAndGet());
     }
 

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/ExpressionContext.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/ExpressionContext.java
@@ -12,9 +12,11 @@ import com.github.anhdat.models.MatrixResponse;
  */
 class ExpressionContext {
     private PrometheusApiClient prometheusClient;
+    private long timestamp;
 
-    ExpressionContext(PrometheusApiClient prometheusClient) {
+    ExpressionContext(PrometheusApiClient prometheusClient, long timestamp) {
 	this.prometheusClient = prometheusClient;
+	this.timestamp = timestamp;
     }
 
     /**
@@ -28,10 +30,9 @@ class ExpressionContext {
      * @return sum of values from the countsSeries matching each distinct value of the stampsSeries
      */
     public float sumPeriods(String countsSeries, String stampsSeries, long from) throws IOException {
-	long now = System.currentTimeMillis() / 1000;
-	String range = "[" + (now - from) +"s]";
-	MatrixResponse rc = prometheusClient.queryMatrix(countsSeries+range, ""+now);
-	MatrixResponse rs = prometheusClient.queryMatrix(stampsSeries+range, ""+now);
+	String range = "[" + (timestamp - from) +"s]";
+	MatrixResponse rc = prometheusClient.queryMatrix(countsSeries+range, ""+timestamp);
+	MatrixResponse rs = prometheusClient.queryMatrix(stampsSeries+range, ""+timestamp);
 	List<List<Float>> stamps = rs.getData().getResult().get(0).getValues();
 	HashSet<Float> uniqueStamps = new HashSet<>();
 	HashSet<Float> uniqueStampsStamps = new HashSet<>();

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/MetricsProvider.java
@@ -15,7 +15,7 @@ public interface MetricsProvider {
     /**
      * Delivers metric details.
      */
-    MetricEntry deliver(String resourceId, String metricId, String from, String to);
+    MetricEntry deliver(String resourceId, String metricId, long timestamp);
     
     /**
      * Lists metric identifiers for a given resource.

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
@@ -48,7 +48,7 @@ public class PrometheusMetricsProvider implements MetricsProvider {
     }
     
     @Override
-    public MetricEntry deliver(String resourceId, String metricId, String from, String to) {
+    public MetricEntry deliver(String resourceId, String metricId, long timestamp) {
         try {
             PrometheusMetricMeta meta = mappingProvider.get(resourceId, metricId);
             if (meta!=null) {

--- a/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
+++ b/metrics-delivery-endpoint-impl/src/main/java/eu/openaire/mas/delivery/provider/PrometheusMetricsProvider.java
@@ -52,7 +52,7 @@ public class PrometheusMetricsProvider implements MetricsProvider {
         try {
             PrometheusMetricMeta meta = mappingProvider.get(resourceId, metricId);
             if (meta!=null) {
-		return runQuery(resourceId, metricId, meta.getQuery());
+		return runQuery(resourceId, metricId, meta.getQuery(), timestamp);
             } else {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, 
                         String.format("unable to find query mappings for "
@@ -66,14 +66,13 @@ public class PrometheusMetricsProvider implements MetricsProvider {
         
     }
 
-    private MetricEntry runQuery(String resourceId, String metricId, String query) {
+    private MetricEntry runQuery(String resourceId, String metricId, String query, long timestamp) {
 	try {
 	    if (query.startsWith(SPEL_PREFIX)) {
-		float value = runSpEL(query.substring(SPEL_PREFIX.length()));
+		float value = runSpEL(query.substring(SPEL_PREFIX.length()), timestamp);
 		return new MetricEntry(resourceId, metricId, value);
 	    }
-	    // FIXME it is just a sample, include "from" and "to" params in querying
-	    VectorResponse resp = prometheusClient.query(query);
+	    VectorResponse resp = prometheusClient.query(query, ""+timestamp);
 	    if (STATUS_SUCCESS.equals(resp.getStatus())) {
 		float value = resp.getData().getResult().get(0).getValue().get(1);
 		return new MetricEntry(resourceId, metricId, value);
@@ -86,10 +85,10 @@ public class PrometheusMetricsProvider implements MetricsProvider {
 	}
     }
 
-    private float runSpEL(String query) {
+    private float runSpEL(String query, long timestamp) {
 	SpelExpressionParser parser = new SpelExpressionParser();
 	Expression exp = parser.parseExpression(query);
-	ExpressionContext ec = new ExpressionContext(prometheusClient);
+	ExpressionContext ec = new ExpressionContext(prometheusClient, timestamp);
 	return exp.getValue(ec, Float.class);
     }
 

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -41,7 +41,7 @@ public class MetricsDeliveryControllerTest {
         String name = "someName";
         float value = 1;
         MetricEntry metricEntry = new MetricEntry(familyId, name, value);
-        Mockito.when(metricsProvider.deliver(familyId, name, null, null)).thenReturn(metricEntry);
+        Mockito.when(metricsProvider.deliver(familyId, name, 0)).thenReturn(metricEntry);
         
         // execute
 	MetricEntry result = metricsDeliveryController.deliver(familyId, name, 0l);

--- a/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
+++ b/metrics-delivery-endpoint-impl/src/test/java/eu/openaire/mas/delivery/MetricsDeliveryControllerTest.java
@@ -44,7 +44,7 @@ public class MetricsDeliveryControllerTest {
         Mockito.when(metricsProvider.deliver(familyId, name, null, null)).thenReturn(metricEntry);
         
         // execute
-        MetricEntry result = metricsDeliveryController.deliver(familyId, name);
+	MetricEntry result = metricsDeliveryController.deliver(familyId, name, 0l);
         
         // assert
         assertNotNull(result);


### PR DESCRIPTION
Closes #23.

Add an optional `time` parameter: unix timestamp defaulting to the current server time, to `/metrics​/{resourceId}​/{metricId}​/value`.

Use it in queries to provide a metric value for the specified moment.