### PR TITLE
Handle queries for counter increases from a specific timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ For more complex cases it can reference a custom computation implemented in Java
 
 #### Complex cases
 
+##### Range vectors
+
+In PromQL range vectors are specified by giving their duration. We sometimes need to calculate eg. `increase` over a range that starts a specific point in time instead. For this placing a special "#R#" token instead of the range duration is supported, eg. `{"query": "increase(some_series[#R#])"}`
+
+Before the query is sent to Prometheus the token is replaced with the duration in seconds between the query time and the value of the `counter.range.start` application property.
+
+##### Custom computations
+
 Instead of a PromQL query the `query` can be "#" followed by a [Spring Expression Language](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#expressions) (SpEL) expression.
 
 This is used for cases where a single PromQL query cannot be used to get the interesting value and more complex processing is needed.

--- a/metrics-delivery-endpoint-impl/src/main/resources/application.properties
+++ b/metrics-delivery-endpoint-impl/src/main/resources/application.properties
@@ -3,3 +3,5 @@ config.directory=${user.home}/mas
 metrics.mapping.location=file:${config.directory}/metrics_mappings.json
 metadata.mapping.location=file:${config.directory}/metadata_mappings.json
 prometheus.server.location=http://localhost:9090/
+
+counter.range.start=1609459200


### PR DESCRIPTION
We need to be able to calculate `increase` for a range that is not of
a predetermined length but instead starts at a specific point in time.

PromQL has only syntax for the former. So to transform the second case
into the first allow placing a "#R#" token in queries configuration
instead of a range specification.

Before the query is sent to Prometheus the token is replaced by an
actual range in seconds, calculated from the query time and a configured
(in application properties) range start time.

For now a global range start value should be enough. Many of the
affected metrics are updated only rarely (monthly), so while an
increase from the project start time is useful others may not be.