### PR TITLE
Expose application build information over HTTP

### DIFF
--- a/metrics-delivery-endpoint-impl/pom.xml
+++ b/metrics-delivery-endpoint-impl/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+	<dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+	</dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -69,6 +74,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+		<executions>
+                  <execution>
+                    <goals>
+                      <goal>build-info</goal>
+                    </goals>
+                  </execution>
+		</executions>
             </plugin>
         </plugins>
     </build>

--- a/metrics-delivery-endpoint-impl/src/main/resources/application.properties
+++ b/metrics-delivery-endpoint-impl/src/main/resources/application.properties
@@ -5,3 +5,7 @@ metadata.mapping.location=file:${config.directory}/metadata_mappings.json
 prometheus.server.location=http://localhost:9090/
 
 counter.range.start=1609459200
+
+#Spring boot actuator
+management.endpoints.web.base-path=/-
+management.endpoints.web.exposure.include=health,info


### PR DESCRIPTION
Closes #27 - expose application version information over HTTP.
Use spring-boot-actuator support for exposing build information:
it additionally contains project artifact and group ids, name and build
time. The information is exposed as JSON at the /-/info path.

Add spring-boot-starter-actuator dependency to the application.
Add build-info execution to the spring-boot-maven-plugin configuration
to generate the META-INF/build-info.properties file used by the info
endpoint.
Set application properties to map the actuator endpoints under '/-'
(personal preference for 'meta' paths) and to expose the info endpoint
in addition to the default health endpoint.